### PR TITLE
Remove the obsolete step of update docker tag

### DIFF
--- a/docs/pai-management/doc/how-to-generate-cluster-config.md
+++ b/docs/pai-management/doc/how-to-generate-cluster-config.md
@@ -74,17 +74,7 @@ cd /pai
 python paictl.py config generate -i /pai/deployment/quick-start/quick-start.yaml -o ~/pai-config -f
 ```
 
-##### (2) update docker tag to release version
-
-```bash
-vi ~/pai-config/services-configuration.yaml
-```
-For example: v0.x.y branch, user should change docker-tag to v0.x.y.
-```bash
-docker-tag: v0.x.y
-```
-
-##### (3) changing gpu count and type
+##### (2) changing gpu count and type
 
 Quick start will generate node with 1 gpu with type generic, this may not suit your situation, for example, if you have two types of machines, and one type has 4 Tesla K80 gpu cards, and another has 2 Tesla P100 cards, you should modify your ~/pai-config/layout.yaml as following:
 


### PR DESCRIPTION
There's no "docker tag" in services-configuration.yaml, and this step should be removed.