### PR TITLE
Update docker-tag to docker-registry.tag

### DIFF
--- a/docs/pai-management/doc/how-to-generate-cluster-config.md
+++ b/docs/pai-management/doc/how-to-generate-cluster-config.md
@@ -79,9 +79,11 @@ python paictl.py config generate -i /pai/deployment/quick-start/quick-start.yaml
 ```bash
 vi ~/pai-config/services-configuration.yaml
 ```
-For example: v0.x.y branch, user should change docker-tag to v0.x.y.
-```bash
-docker-tag: v0.x.y
+For example: v0.x.y branch, user should change docker-registry.tag to v0.x.y.
+```YAML
+docker:
+  ...
+  tag: v0.x.y
 ```
 
 ##### (3) changing gpu count and type


### PR DESCRIPTION
There's no docker-tag in pai/examples/cluster-configuration/services-configuration.yaml but only docker-registry.tag. Correct the document to make it clear that docker-registry.tag is the one to be modified.